### PR TITLE
feat : add validation contraint to entities + add TimestampableTrait

### DIFF
--- a/migrations/Version20250904151954.php
+++ b/migrations/Version20250904151954.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20250904151954 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE certification CHANGE updated_at updated_at DATETIME NOT NULL COMMENT \'(DC2Type:datetime_immutable)\'');
+        $this->addSql('ALTER TABLE `order` ADD updated_at DATETIME NOT NULL COMMENT \'(DC2Type:datetime_immutable)\', DROP upadated_at');
+        $this->addSql('ALTER TABLE order_item ADD updated_at DATETIME NOT NULL COMMENT \'(DC2Type:datetime_immutable)\'');
+        $this->addSql('ALTER TABLE theme ADD updated_at DATETIME NOT NULL COMMENT \'(DC2Type:datetime_immutable)\'');
+        $this->addSql('ALTER TABLE user CHANGE name name VARCHAR(20) NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE certification CHANGE updated_at updated_at DATETIME DEFAULT NULL COMMENT \'(DC2Type:datetime_immutable)\'');
+        $this->addSql('ALTER TABLE theme DROP updated_at');
+        $this->addSql('ALTER TABLE user CHANGE name name VARCHAR(255) NOT NULL');
+        $this->addSql('ALTER TABLE order_item DROP updated_at');
+        $this->addSql('ALTER TABLE `order` ADD upadated_at DATETIME DEFAULT NULL COMMENT \'(DC2Type:datetime_immutable)\', DROP updated_at');
+    }
+}

--- a/src/Entity/Certification.php
+++ b/src/Entity/Certification.php
@@ -3,22 +3,30 @@
 namespace App\Entity;
 
 use ApiPlatform\Metadata\ApiResource;
+use App\Entity\Trait\TimestampableTrait;
 use App\Repository\CertificationRepository;
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Validator\Constraints as Assert;
 
 #[ORM\Entity(repositoryClass: CertificationRepository::class)]
 #[ApiResource]
+#[ORM\HasLifecycleCallbacks]
 class Certification
 {
+    use TimestampableTrait;
+
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column]
     private ?int $id = null;
 
     #[ORM\Column(length: 255)]
+    #[Assert\NotBlank]
+    #[Assert\Length(max: 255)]
     private ?string $title = null;
 
     #[ORM\Column]
+    #[Assert\DateTime]
     private ?\DateTime $date = null;
 
     #[ORM\ManyToOne(inversedBy: 'certifications')]
@@ -28,12 +36,6 @@ class Certification
     #[ORM\ManyToOne(inversedBy: 'certifications')]
     #[ORM\JoinColumn(nullable: false)]
     private ?Theme $theme = null;
-
-    #[ORM\Column(nullable: false)]
-    private ?\DateTimeImmutable $created_at = null;
-
-    #[ORM\Column(nullable: true)]
-    private ?\DateTimeImmutable $updated_at = null;
 
     #[ORM\ManyToOne(inversedBy: 'certifications')]
     private ?User $created_by = null;
@@ -87,30 +89,6 @@ class Certification
     public function setTheme(?Theme $theme): static
     {
         $this->theme = $theme;
-
-        return $this;
-    }
-
-    public function getCreatedAt(): ?\DateTimeImmutable
-    {
-        return $this->created_at;
-    }
-
-    public function setCreatedAt(\DateTimeImmutable $created_at): static
-    {
-        $this->created_at = $created_at;
-
-        return $this;
-    }
-
-    public function getUpdatedAt(): ?\DateTimeImmutable
-    {
-        return $this->updated_at;
-    }
-
-    public function setUpdatedAt(?\DateTimeImmutable $updated_at): static
-    {
-        $this->updated_at = $updated_at;
 
         return $this;
     }

--- a/src/Entity/Cursus.php
+++ b/src/Entity/Cursus.php
@@ -12,7 +12,7 @@ use Doctrine\ORM\Mapping as ORM;
 #[ApiResource]
 class Cursus extends Product
 {
-    #[ORM\ManyToOne(inversedBy: 'cursuses')]
+    #[ORM\ManyToOne(inversedBy: 'cursus')]
     #[ORM\JoinColumn(nullable: false)]
     private ?Theme $theme = null;
 
@@ -26,12 +26,12 @@ class Cursus extends Product
      * @var Collection<int, EnrollmentCursus>
      */
     #[ORM\OneToMany(targetEntity: EnrollmentCursus::class, mappedBy: 'cursus')]
-    private Collection $enrollmentCursuses;
+    private Collection $enrollmentCursus;
 
     public function __construct()
     {
         $this->lessons = new ArrayCollection();
-        $this->enrollmentCursuses = new ArrayCollection();
+        $this->enrollmentCursus = new ArrayCollection();
     }
 
     public function getTheme(): ?Theme
@@ -79,15 +79,15 @@ class Cursus extends Product
     /**
      * @return Collection<int, EnrollmentCursus>
      */
-    public function getEnrollmentCursuses(): Collection
+    public function getEnrollmentCursus(): Collection
     {
-        return $this->enrollmentCursuses;
+        return $this->enrollmentCursus;
     }
 
     public function addEnrollmentCursus(EnrollmentCursus $enrollmentCursus): static
     {
-        if (!$this->enrollmentCursuses->contains($enrollmentCursus)) {
-            $this->enrollmentCursuses->add($enrollmentCursus);
+        if (!$this->enrollmentCursus->contains($enrollmentCursus)) {
+            $this->enrollmentCursus->add($enrollmentCursus);
             $enrollmentCursus->setCursus($this);
         }
 
@@ -96,7 +96,7 @@ class Cursus extends Product
 
     public function removeEnrollmentCursus(EnrollmentCursus $enrollmentCursus): static
     {
-        if ($this->enrollmentCursuses->removeElement($enrollmentCursus)) {
+        if ($this->enrollmentCursus->removeElement($enrollmentCursus)) {
             // set the owning side to null (unless already changed)
             if ($enrollmentCursus->getCursus() === $this) {
                 $enrollmentCursus->setCursus(null);

--- a/src/Entity/EnrollmentCursus.php
+++ b/src/Entity/EnrollmentCursus.php
@@ -2,12 +2,17 @@
 
 namespace App\Entity;
 
+use App\Entity\Trait\TimestampableTrait;
 use App\Repository\EnrollmentCursusRepository;
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Validator\Constraints as Assert;
 
 #[ORM\Entity(repositoryClass: EnrollmentCursusRepository::class)]
+#[ORM\HasLifecycleCallbacks]
 class EnrollmentCursus
 {
+    use TimestampableTrait;
+
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column]
@@ -22,13 +27,8 @@ class EnrollmentCursus
     private ?Cursus $cursus = null;
 
     #[ORM\Column]
+    #[Assert\DateTime]
     private ?\DateTime $inscription = null;
-
-    #[ORM\Column]
-    private ?\DateTimeImmutable $created_at = null;
-
-    #[ORM\Column]
-    private ?\DateTimeImmutable $updated_at = null;
 
     public function getId(): ?int
     {
@@ -67,30 +67,6 @@ class EnrollmentCursus
     public function setInscription(\DateTime $inscription): static
     {
         $this->inscription = $inscription;
-
-        return $this;
-    }
-
-    public function getCreatedAt(): ?\DateTimeImmutable
-    {
-        return $this->created_at;
-    }
-
-    public function setCreatedAt(\DateTimeImmutable $created_at): static
-    {
-        $this->created_at = $created_at;
-
-        return $this;
-    }
-
-    public function getUpdatedAt(): ?\DateTimeImmutable
-    {
-        return $this->updated_at;
-    }
-
-    public function setUpdatedAt(\DateTimeImmutable $updated_at): static
-    {
-        $this->updated_at = $updated_at;
 
         return $this;
     }

--- a/src/Entity/EnrollmentLesson.php
+++ b/src/Entity/EnrollmentLesson.php
@@ -2,12 +2,17 @@
 
 namespace App\Entity;
 
+use App\Entity\Trait\TimestampableTrait;
 use App\Repository\EnrollmentLessonRepository;
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Validator\Constraints as Assert;
 
 #[ORM\Entity(repositoryClass: EnrollmentLessonRepository::class)]
+#[ORM\HasLifecycleCallbacks]
 class EnrollmentLesson
 {
+    use TimestampableTrait;
+
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column]
@@ -22,13 +27,8 @@ class EnrollmentLesson
     private ?Lesson $lesson = null;
 
     #[ORM\Column]
+    #[Assert\DateTime]
     private ?\DateTime $inscription = null;
-
-    #[ORM\Column]
-    private ?\DateTimeImmutable $created_at = null;
-
-    #[ORM\Column]
-    private ?\DateTimeImmutable $updated_at = null;
 
     public function getId(): ?int
     {
@@ -67,30 +67,6 @@ class EnrollmentLesson
     public function setInscription(\DateTime $inscription): static
     {
         $this->inscription = $inscription;
-
-        return $this;
-    }
-
-    public function getCreatedAt(): ?\DateTimeImmutable
-    {
-        return $this->created_at;
-    }
-
-    public function setCreatedAt(\DateTimeImmutable $created_at): static
-    {
-        $this->created_at = $created_at;
-
-        return $this;
-    }
-
-    public function getUpdatedAt(): ?\DateTimeImmutable
-    {
-        return $this->updated_at;
-    }
-
-    public function setUpdatedAt(\DateTimeImmutable $updated_at): static
-    {
-        $this->updated_at = $updated_at;
 
         return $this;
     }

--- a/src/Entity/Order.php
+++ b/src/Entity/Order.php
@@ -3,37 +3,40 @@
 namespace App\Entity;
 
 use ApiPlatform\Metadata\ApiResource;
+use App\Entity\Trait\TimestampableTrait;
 use App\Repository\OrderRepository;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Validator\Constraints as Assert;
 
 #[ORM\Entity(repositoryClass: OrderRepository::class)]
 #[ORM\Table(name: '`order`')]
 #[ApiResource]
+#[ORM\HasLifecycleCallbacks]
 class Order
 {
+    use TimestampableTrait;
+
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column]
     private ?int $id = null;
 
     #[ORM\Column]
+    #[Assert\DateTime]
     private ?\DateTime $date = null;
 
     #[ORM\Column(type: Types::DECIMAL, precision: 10, scale: 0)]
+    #[Assert\NotNull]
+    #[Assert\Positive(message : 'Le prix du produit doit être positif')]
+    #[Assert\Type(type: 'numeric')]
     private ?string $total = null;
 
     #[ORM\ManyToOne(inversedBy: 'orders')]
     #[ORM\JoinColumn(nullable: false)]
     private ?User $user = null;
-
-    #[ORM\Column]
-    private ?\DateTimeImmutable $created_at = null;
-
-    #[ORM\Column(nullable: true)]
-    private ?\DateTimeImmutable $upadated_at = null;
 
     /**
      * @var Collection<int, Orderitem>
@@ -87,29 +90,6 @@ class Order
         return $this;
     }
 
-    public function getCreatedAt(): ?\DateTimeImmutable
-    {
-        return $this->created_at;
-    }
-
-    public function setCreatedAt(\DateTimeImmutable $created_at): static
-    {
-        $this->created_at = $created_at;
-
-        return $this;
-    }
-
-    public function getUpadatedAt(): ?\DateTimeImmutable
-    {
-        return $this->upadated_at;
-    }
-
-    public function setUpadatedAt(?\DateTimeImmutable $upadated_at): static
-    {
-        $this->upadated_at = $upadated_at;
-
-        return $this;
-    }
 
     /**
      * @return Collection<int, Orderitem>

--- a/src/Entity/OrderItem.php
+++ b/src/Entity/OrderItem.php
@@ -3,28 +3,33 @@
 namespace App\Entity;
 
 use ApiPlatform\Metadata\ApiResource;
+use App\Entity\Trait\TimestampableTrait;
 use App\Repository\OrderitemRepository;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Validator\Constraints as Assert;
 
 #[ORM\Entity(repositoryClass: OrderitemRepository::class)]
 #[ApiResource]
+#[ORM\HasLifecycleCallbacks]
 class OrderItem
 {
+    use TimestampableTrait;
+
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column]
     private ?int $id = null;
 
     #[ORM\Column(type: Types::DECIMAL, precision: 10, scale: 0)]
+    #[Assert\NotNull]
+    #[Assert\Positive(message : 'Le prix du produit doit être positif')]
+    #[Assert\Type(type: 'numeric')]
     private ?string $price = null;
 
     #[ORM\ManyToOne(inversedBy: 'orderitems')]
     #[ORM\JoinColumn(nullable: false)]
     private ?Order $orderId = null;
-
-    #[ORM\Column]
-    private ?\DateTimeImmutable $created_at = null;
 
     #[ORM\ManyToOne(inversedBy: 'orderitems')]
     #[ORM\JoinColumn(nullable: false)]
@@ -55,18 +60,6 @@ class OrderItem
     public function setOrderId(?Order $orderId): static
     {
         $this->orderId = $orderId;
-
-        return $this;
-    }
-
-    public function getCreatedAt(): ?\DateTimeImmutable
-    {
-        return $this->created_at;
-    }
-
-    public function setCreatedAt(\DateTimeImmutable $created_at): static
-    {
-        $this->created_at = $created_at;
 
         return $this;
     }

--- a/src/Entity/Product.php
+++ b/src/Entity/Product.php
@@ -3,41 +3,45 @@
 namespace App\Entity;
 
 use ApiPlatform\Metadata\ApiResource;
+use App\Entity\Trait\TimestampableTrait;
 use App\Enum\ProductType;
 use App\Repository\ProductRepository;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Validator\Constraints as Assert;
 
 #[ORM\Entity(repositoryClass: ProductRepository::class)]
 #[ORM\InheritanceType("SINGLE_TABLE")]
 #[ORM\DiscriminatorColumn(name: "discr", type: "string")]
 #[ORM\DiscriminatorMap(["cursus" => Cursus::class, "lesson" => Lesson::class])]
 #[ApiResource]
+#[ORM\HasLifecycleCallbacks]
 class Product
 {
+    use TimestampableTrait;
+
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column]
     private ?int $id = null;
 
     #[ORM\Column(length: 255)]
+    #[Assert\NotBlank(message : 'Le nom du produit est obligatoire')]
     private ?string $name = null;
 
     #[ORM\Column]
+    #[Assert\NotNull]
+    #[Assert\Positive(message : 'Le prix du produit doit être positif')]
+    #[Assert\Type(type: 'numeric')]
     private ?float $price = null;
 
     #[ORM\Column(enumType: ProductType::class)]
+    #[Assert\NotNull(message : 'Choisir un type de produit')]
     private ?ProductType $type = null;
-
-    #[ORM\Column]
-    private ?\DateTimeImmutable $created_at = null;
 
     #[ORM\ManyToOne(inversedBy: 'products')]
     private ?User $created_by = null;
-
-    #[ORM\Column]
-    private ?\DateTimeImmutable $updated_at = null;
 
     #[ORM\ManyToOne(inversedBy: 'updateProducts')]
     private ?User $updated_by = null;
@@ -94,18 +98,6 @@ class Product
         return $this;
     }
 
-    public function getCreatedAt(): ?\DateTimeImmutable
-    {
-        return $this->created_at;
-    }
-
-    public function setCreatedAt(\DateTimeImmutable $created_at): static
-    {
-        $this->created_at = $created_at;
-
-        return $this;
-    }
-
     public function getCreatedBy(): ?User
     {
         return $this->created_by;
@@ -118,17 +110,6 @@ class Product
         return $this;
     }
 
-    public function getUpdatedAt(): ?\DateTimeImmutable
-    {
-        return $this->updated_at;
-    }
-
-    public function setUpdatedAt(\DateTimeImmutable $updated_at): static
-    {
-        $this->updated_at = $updated_at;
-
-        return $this;
-    }
 
     public function getUpdatedBy(): ?User
     {

--- a/src/Entity/Theme.php
+++ b/src/Entity/Theme.php
@@ -7,21 +7,24 @@ use App\Repository\ThemeRepository;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Validator\Constraints as Assert;
+use App\Entity\Trait\TimestampableTrait;
 
 #[ORM\Entity(repositoryClass: ThemeRepository::class)]
 #[ApiResource]
+#[ORM\HasLifecycleCallbacks]
 class Theme
 {
+    use TimestampableTrait;
+
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column]
     private ?int $id = null;
 
     #[ORM\Column(length: 255)]
+    #[Assert\NotBlank(message: 'Le nom du Théme est obligatoire')]
     private ?string $name = null;
-
-    #[ORM\Column]
-    private ?\DateTimeImmutable $created_at = null;
 
     #[ORM\ManyToOne(inversedBy: 'themes')]
     private ?User $created_by = null;
@@ -30,7 +33,7 @@ class Theme
      * @var Collection<int, Cursus>
      */
     #[ORM\OneToMany(targetEntity: Cursus::class, mappedBy: 'theme', orphanRemoval: true)]
-    private Collection $cursuses;
+    private Collection $cursus;
 
     /**
      * @var Collection<int, Certification>
@@ -40,7 +43,7 @@ class Theme
 
     public function __construct()
     {
-        $this->cursuses = new ArrayCollection();
+        $this->cursus = new ArrayCollection();
         $this->certifications = new ArrayCollection();
     }
 
@@ -57,18 +60,6 @@ class Theme
     public function setName(string $name): static
     {
         $this->name = $name;
-
-        return $this;
-    }
-
-    public function getCreatedAt(): ?\DateTimeImmutable
-    {
-        return $this->created_at;
-    }
-
-    public function setCreatedAt(\DateTimeImmutable $created_at): static
-    {
-        $this->created_at = $created_at;
 
         return $this;
     }
@@ -90,13 +81,13 @@ class Theme
      */
     public function getCursuses(): Collection
     {
-        return $this->cursuses;
+        return $this->cursus;
     }
 
     public function addCursus(Cursus $cursus): static
     {
-        if (!$this->cursuses->contains($cursus)) {
-            $this->cursuses->add($cursus);
+        if (!$this->cursus->contains($cursus)) {
+            $this->cursus->add($cursus);
             $cursus->setTheme($this);
         }
 
@@ -105,7 +96,7 @@ class Theme
 
     public function removeCursus(Cursus $cursus): static
     {
-        if ($this->cursuses->removeElement($cursus)) {
+        if ($this->cursus->removeElement($cursus)) {
             // set the owning side to null (unless already changed)
             if ($cursus->getTheme() === $this) {
                 $cursus->setTheme(null);

--- a/src/Entity/Trait/TimestampableTrait.php
+++ b/src/Entity/Trait/TimestampableTrait.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Entity\Trait;
+
+use DateTimeImmutable;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\HasLifecycleCallbacks]
+trait TimestampableTrait
+{
+    #[ORM\Column]
+    private ?\DateTimeImmutable $created_at=null;
+
+    #[ORM\Column]
+    private ?\DateTimeImmutable $updated_at=null;
+
+    #[ORM\PrePersist]
+    public function setCreatedValue(): void
+    {
+        $this->created_at = new \DateTimeImmutable();
+        $this->updated_at = new DateTimeImmutable();
+    }
+
+    #[ORM\PreUpdate]
+    public function setUpdatedValue(): void
+    {
+        $this->upadated_at = new \DateTimeImmutable();
+    }
+
+    public function getCreatedAt(): ?\DateTimeImmutable
+    {
+        return $this->created_at;
+    }
+
+    public function getUpadatedAt(): ?\DateTimeImmutable
+    {
+        return $this->updated_at;
+    }
+}

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -8,33 +8,50 @@ use App\Repository\UserRepository;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Validator\Constraints as Assert;
+use App\Entity\Trait\TimestampableTrait;
 
 #[ORM\Entity(repositoryClass: UserRepository::class)]
 #[ApiResource]
+#[ORM\HasLifecycleCallbacks]
 class User
 {
+    use TimestampableTrait;
+
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column]
     private ?int $id = null;
 
-    #[ORM\Column(length: 255)]
+    #[ORM\Column(length: 20)]
+    #[Assert\NotBlank(message: 'Le nom ne peut pas être vide.')]
+    #[Assert\Length(
+        min: 2,
+        max: 20,
+        minMessage: "Le nom doit contenir au moins {{ limit }} caractères.",
+        maxMessage: "Le nom ne peut pas dépasser {{ limit }} caractères."
+    )]
     private ?string $name = null;
 
     #[ORM\Column(length: 255)]
+    #[Assert\NotBlank]
+    #[Assert\Email(
+        message: "L'email {{ value }} n'est pas valide.",
+    )] 
     private ?string $email = null;
 
     #[ORM\Column(length: 255)]
+    #[Assert\NotBlank(message: 'Le mot de passe est obligatoire')]
+    #[Assert\Length(
+        min: 6, 
+        max: 255,
+        minMessage: "Le mot de passe doit contenir au moins {{ limit }} caractères."
+        )]
     private ?string $password = null;
 
     #[ORM\Column(enumType: UserRole::class)]
+    #[Assert\NotNull(message: "Le rôle est obligatoire.")]
     private ?UserRole $role = null;
-
-    #[ORM\Column]
-    private ?\DateTimeImmutable $created_at = null;
-
-    #[ORM\Column]
-    private ?\DateTimeImmutable $updated_at = null;
 
     /**
      * @var Collection<int, Theme>
@@ -138,30 +155,6 @@ class User
     public function setRole(UserRole $role): static
     {
         $this->role = $role;
-
-        return $this;
-    }
-
-    public function getCreatedAt(): ?\DateTimeImmutable
-    {
-        return $this->created_at;
-    }
-
-    public function setCreatedAt(\DateTimeImmutable $created_at): static
-    {
-        $this->created_at = $created_at;
-
-        return $this;
-    }
-
-    public function getUpdatedAt(): ?\DateTimeImmutable
-    {
-        return $this->updated_at;
-    }
-
-    public function setUpdatedAt(\DateTimeImmutable $updated_at): static
-    {
-        $this->updated_at = $updated_at;
 
         return $this;
     }


### PR DESCRIPTION
Ajout des contraintes nécessaires aux entités et création d'un trait pour gérer automatiquement les champs created_at et updated_at. Nouvelle migration effectuée.

Fermeture de l'issue #11